### PR TITLE
Fix Error handler to return json response

### DIFF
--- a/pubgate/__init__.py
+++ b/pubgate/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"
 
 
 KEY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "storage")

--- a/pubgate/utils/networking.py
+++ b/pubgate/utils/networking.py
@@ -23,12 +23,14 @@ async def verify_request(request) -> bool:
     return verify(hsig, request, actor)
 
 
-async def fetch(url):
+async def fetch(url, status=False):
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers={"accept": 'application/activity+json',
                                              "user-agent": f"PubGate v:{__version__}"}
                                 ) as resp:
             logger.info(f"Fetch {url}, status: {resp.status}, {resp.reason}")
+            if status:
+                return resp.status, await resp.json(encoding='utf-8')
             return await resp.json(encoding='utf-8')
 
 


### PR DESCRIPTION
Replaces #44 for https://github.com/autogestion/pubgate-philip/pull/21
@traumschule  check this solution
First clause is for designed error (inherited from SanicException )
Means this errors are options expected by client 

Second clause is for internal fails. In debug mode it still returns exception description, in production mode it returns fixed text.

And it it always a json :)